### PR TITLE
Minor fixes to documentation and new compiler/stack versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.2"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.2], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@ module Main where
 
 import Data.Octree as O
 
-import Data.Vector.V3
+import Linear
 
-main = do let oct = fromList [(Vector3 1 2 3, "a"),
-                              (Vector3 3 4 5, "b"),
-                              (Vector3 8 8 8, "c")]
+main = do let oct = fromList [(V3 1 2 3, "a"),
+                              (V3 3 4 5, "b"),
+                              (V3 8 8 8, "c")]
               report msg elt = putStrLn $ msg ++ show elt
-          report "Nearest     :" $ O.nearest     oct     $ Vector3 2 2 3
-          report "Within range:" $ O.withinRange oct 5.0 $ Vector3 2 2 3
+          report "Nearest     :" $ O.nearest     oct     $ V3 2 2 3
+          report "Within range:" $ O.withinRange oct 5.0 $ V3 2 2 3
           return ()
 ~~~
 
-*For now it uses AC-Vector package for vectors, but I may change it to use Tensor package used by OpenGL package, if there is interest.*
+*For now it uses linear package for vectors, but I may change it to use Tensor package used by OpenGL package, if there is interest.*
 *So far I still wait for package with vector operations (like dot, cross producton, vector projection and rejection) on Tensor types.*
 
 Official releases are on [Hackage](http://hackage.haskell.org/package/Octree).

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.0
+resolver: lts-11.9
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Hi, I'm just trying to figure out why this package is not in the latest stack lts and nightly snapshots. (https://www.stackage.org/package/Octree). It seems to build fine with lts-11.9 and the latest nightlies. Also some documentation fixes for the README.md