### PR TITLE
GHC 8.8.3 (stack + cabal) and GHC 8.10.1 (cabal)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
     - compiler: "ghc-8.6.5"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.5], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.8.3"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.8.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ matrix:
     - compiler: "ghc-8.8.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.8.3], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.10.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.10.1], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/Octree.cabal
+++ b/Octree.cabal
@@ -23,13 +23,14 @@ tested-with:         GHC==7.10.3
                     ,GHC==8.2.2
                     ,GHC==8.4.3
                     ,GHC==8.6.5
+                    ,GHC==8.8.3
 
 source-repository head
   type:     git
   location: git@github.com:mgajda/octree.git
 
 Library
-   build-depends:    base>=4.0 && < 4.13,
+   build-depends:    base>=4.0 && < 4.14,
                      deepseq >= 1.2.0.0,
                      lens   >= 4.13.0,
                      linear >= 1.18.0,
@@ -41,7 +42,7 @@ Library
 
 Test-suite test_Octree
   Type:              exitcode-stdio-1.0
-  Build-depends:     base>=4.0 && < 4.13, linear >= 1.20.0, QuickCheck >= 2.8.0,
+  Build-depends:     base>=4.0 && < 4.14, linear >= 1.20.0, QuickCheck >= 2.8.0,
                      deepseq >= 1.2.0.0,
                      lens   >= 4.13.0
   other-modules:     Data.Octree
@@ -52,7 +53,7 @@ benchmark bench-octree
   type:             exitcode-stdio-1.0
   other-modules:    Data.Octree.Internal
   main-is:          tests/benchmark.hs
-  build-depends:    base >=4.0 && <4.13, deepseq, ghc-prim,
+  build-depends:    base >=4.0 && <4.14, deepseq, ghc-prim,
                     linear >= 1.18.0, QuickCheck >= 2.8.0,
                     lens   >= 4.13.0,
                     criterion

--- a/Octree.cabal
+++ b/Octree.cabal
@@ -24,13 +24,14 @@ tested-with:         GHC==7.10.3
                     ,GHC==8.4.3
                     ,GHC==8.6.5
                     ,GHC==8.8.3
+                    ,GHC==8.10.1
 
 source-repository head
   type:     git
   location: git@github.com:mgajda/octree.git
 
 Library
-   build-depends:    base>=4.0 && < 4.14,
+   build-depends:    base>=4.0 && < 4.15,
                      deepseq >= 1.2.0.0,
                      lens   >= 4.13.0,
                      linear >= 1.18.0,
@@ -42,7 +43,7 @@ Library
 
 Test-suite test_Octree
   Type:              exitcode-stdio-1.0
-  Build-depends:     base>=4.0 && < 4.14, linear >= 1.20.0, QuickCheck >= 2.8.0,
+  Build-depends:     base>=4.0 && < 4.15, linear >= 1.20.0, QuickCheck >= 2.8.0,
                      deepseq >= 1.2.0.0,
                      lens   >= 4.13.0
   other-modules:     Data.Octree
@@ -53,7 +54,7 @@ benchmark bench-octree
   type:             exitcode-stdio-1.0
   other-modules:    Data.Octree.Internal
   main-is:          tests/benchmark.hs
-  build-depends:    base >=4.0 && <4.14, deepseq, ghc-prim,
+  build-depends:    base >=4.0 && <4.15, deepseq, ghc-prim,
                     linear >= 1.18.0, QuickCheck >= 2.8.0,
                     lens   >= 4.13.0,
                     criterion

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,8 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-14.4
-#resolver: lts-6.0
+resolver: lts-16.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
- Add support for GHC-8.8.3 (cabal and `stack.yaml`)
- Add support for GHC-8.10.1 (cabal)

This should make it easier to bump the `stack.yaml` LTS version once Stackage moves to GHC-8.10.1 by default.